### PR TITLE
Corrección en los init del Health

### DIFF
--- a/health/redis.go
+++ b/health/redis.go
@@ -12,15 +12,13 @@ var client *redis.Client
 
 func init() {
 	db, err := strconv.Atoi(os.Getenv("REDIS_DB"))
-	if err != nil {
-		panic("No se encontró la variable de entorno REDIS_DB.")
+	if err == nil && os.Getenv("REDIS_ADDR") != "" {
+		client = redis.NewClient(&redis.Options{
+			Addr:     os.Getenv("REDIS_ADDR"),
+			Password: os.Getenv("REDIS_PASS"),
+			DB:       db,
+		})
 	}
-
-	client = redis.NewClient(&redis.Options{
-		Addr:     os.Getenv("REDIS_ADDR"),
-		Password: os.Getenv("REDIS_PASS"),
-		DB:       db,
-	})
 }
 
 func RedisHealthChecker() Checker {

--- a/mssql/mssql.go
+++ b/mssql/mssql.go
@@ -12,14 +12,15 @@ var db *gorm.DB
 
 func init() {
 	args := os.Getenv("SQL_CONNECTION")
-	conn, err := gorm.Open("mssql", args)
-	if err != nil {
-		log.Logger.Error(err.Error())
-	} else {
-		db = conn
-		log.Logger.Info("Se ha conectado exitosamente.")
+	if args != "" {
+		conn, err := gorm.Open("mssql", args)
+		if err != nil {
+			log.Logger.Error(err.Error())
+		} else {
+			db = conn
+			log.Logger.Info("Se ha conectado exitosamente.")
+		}
 	}
-
 }
 
 // GetDB return the database connection

--- a/mysql/mysql.go
+++ b/mysql/mysql.go
@@ -12,12 +12,14 @@ var db *gorm.DB
 
 func init() {
 	args := os.Getenv("MYSQL_CONNECTION")
-	conn, err := gorm.Open("mysql", args)
-	if err != nil {
-		log.Logger.Error(err.Error())
-	} else {
-		db = conn
-		log.Logger.Info("Se ha conectado exitosamente.")
+	if args != "" {
+		conn, err := gorm.Open("mysql", args)
+		if err != nil {
+			log.Logger.Error(err.Error())
+		} else {
+			db = conn
+			log.Logger.Info("Se ha conectado exitosamente.")
+		}
 	}
 }
 


### PR DESCRIPTION
Al incluir el Health, se disparan los init de MSSQL y  MySQL.
Si tu proyecto no usa alguna de las BDs, va a tirar error porque así es como estaba planteado inicialmente.
Ahora, establece la conexión si las variables de entorno están seteadas.