### PR TITLE
Added logic for creation or update of a topic

### DIFF
--- a/AMQStream/extensions.go
+++ b/AMQStream/extensions.go
@@ -1,9 +1,11 @@
 package AMQStream
 
 import (
+	"context"
 	"errors"
 	"os"
 	"sync"
+	"time"
 
 	extension "github.com/architecture-it/go-platform/config"
 	"github.com/architecture-it/go-platform/log"
@@ -42,7 +44,13 @@ func AddKafka() (*config, error) {
 		"message.max.bytes":                   config.MessageMaxBytes,
 		"enable.ssl.certificate.verification": config.EnableSslCertificateVerification,
 	}
-
+	cfg.cfgAdmin = &kafka.ConfigMap{
+		"bootstrap.servers":                   config.BootstrapServers,
+		"group.id":                            config.GroupId,
+		"security.protocol":                   config.SecurityProtocol,
+		"ssl.certificate.location":            config.SslCertificateLocation,
+		"enable.ssl.certificate.verification": config.EnableSslCertificateVerification,
+	}
 	cfg.schemaRegistry = schemaregistry.NewConfig(config.SchemaRegistry)
 
 	cfg.MaxRetry = config.MaxRetry
@@ -130,6 +138,74 @@ func (c *config) ToProducer(event ISpecificRecord, topics []string) *config {
 	return c
 }
 
+func (c *config) CreateOrUpdateTopics(numParts int, topics []string) *config {
+	replicationFactor := 3
+
+	// Create a new AdminClient.
+	// AdminClient can also be instantiated using an existing
+	// Producer or Consumer instance, see NewAdminClientFromProducer and
+	// NewAdminClientFromConsumer.
+	adminClient, err := kafka.NewAdminClient(c.cfgAdmin)
+	if err != nil {
+		log.SugarLogger.Infoln("Failed to create Admin client: %s\n", err)
+		os.Exit(1)
+	}
+
+	// Contexts are used to abort or limit the amount of time
+	// the Admin call blocks waiting for a result.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Create topics on cluster.
+	// Set Admin options to wait for the operation to finish (or at most 60s)
+	maxDur, err := time.ParseDuration("60s")
+	if err != nil {
+		defer time.ParseDuration("60s")
+	}
+	for _, topic := range topics {
+		results, err := adminClient.CreateTopics(
+			ctx,
+			// Multiple topics can be created simultaneously
+			// by providing more TopicSpecification structs here.
+			[]kafka.TopicSpecification{{
+				Topic:             topic,
+				NumPartitions:     numParts,
+				ReplicationFactor: replicationFactor}},
+			// Admin options
+			kafka.SetAdminOperationTimeout(maxDur))
+		if err != nil {
+			log.SugarLogger.Infoln("Failed to create topic: %v\n", err)
+		}
+		// Print results
+		for _, result := range results {
+			if result.Error.Code() == kafka.ErrTopicAlreadyExists {
+				updateTopic(adminClient, ctx, topic, numParts, maxDur)
+			} else {
+				log.SugarLogger.Infoln("%s\n", result)
+			}
+		}
+	}
+	adminClient.Close()
+	return c
+}
+
+func updateTopic(adminClient *kafka.AdminClient, ctx context.Context, topic string, numParts int, maxDur time.Duration) {
+	resultUpdate, err := adminClient.CreatePartitions(ctx, []kafka.PartitionsSpecification{{
+		Topic:      topic,
+		IncreaseTo: numParts,
+	}}, kafka.SetAdminOperationTimeout(maxDur))
+	if err != nil {
+		log.SugarLogger.Infoln("Failed to Update topic: %v\n", err)
+	}
+	for _, result := range resultUpdate {
+		if result.Error.Code() == kafka.ErrNoError || result.Error.Code() == kafka.ErrInvalidPartitions {
+
+		} else {
+			log.SugarLogger.Infoln("%s\n", result)
+		}
+	}
+}
+
 func (c *config) Build() {
 	wg := new(sync.WaitGroup)
 	for _, element := range c.consumers {
@@ -147,5 +223,4 @@ func (c *config) Build() {
 		}()
 	}
 	wg.Wait()
-
 }

--- a/AMQStream/structures.go
+++ b/AMQStream/structures.go
@@ -8,6 +8,7 @@ import (
 )
 
 type config struct {
+	cfgAdmin       *kafka.ConfigMap
 	cfgProducer    *kafka.ConfigMap
 	cfgConsumer    *kafka.ConfigMap
 	schemaRegistry *schemaregistry.Config


### PR DESCRIPTION
### Summary
In this PR, we are adding a new method, called **CreateOrUpdateTopics**, that as its name states will serve to create or update a  Kafka topic from our Go library.

**CreateOrUpdateTopics** is a function that takes two parameters: **numParts** (an int, being the number of partitions that we want in our topic), and **topics** (an array of strings with the names of the topics we want to create). The **replication factor** of the topic is set to 3 so isn't required as input.

First, let's create a brand new topic, called "creacion-topic-6", which will have 6 partitions: 
![creacion topic 6](https://user-images.githubusercontent.com/111450258/199347912-12c1ca93-f572-4c32-85c6-0248842ae468.png)

In the Kafka UI, we see that the topic was successfully created:
![kafka ui creacion topic 6](https://user-images.githubusercontent.com/111450258/199347008-8275695e-d851-49fd-8b9e-637b2648b4fe.png)

Now, if we want to update the number of partitions, we just use the same function, leaving the same topic name and updating the first parameter:
![update topic 6](https://user-images.githubusercontent.com/111450258/199347028-a3ad15da-5828-4ca4-bf1c-2f948071dd64.png)

The topic was successfully updated:
![kafka ui update topic 6](https://user-images.githubusercontent.com/111450258/199347051-26489491-e098-479a-afed-821f8d4afd94.png)

If we want to decrease the number of partitions, the library won't let us:
![update topic 6 fallido](https://user-images.githubusercontent.com/111450258/199347077-596d0287-911c-4983-9f3e-4fd03c82f114.png)

No changes were saved:
![kafka ui update topic 6 fallido](https://user-images.githubusercontent.com/111450258/199347090-c3c096f5-c2f0-4361-aa33-d8985e719948.png)
