### PR TITLE
Validacion de evento nil

### DIFF
--- a/AMQStream/serAndDeser.go
+++ b/AMQStream/serAndDeser.go
@@ -39,6 +39,12 @@ func withoutStrategy(topic string, serdeType serde.Type, schema schemaregistry.S
 func deserializeMessage(c *config, message *kafka.Message, event ISpecificRecord) (ISpecificRecord, error) {
 	client, err := schemaregistry.NewClient(c.schemaRegistry)
 
+	if event == nil {
+		errorMessage := fmt.Sprintf("Event is nil. Key: %s\n", message.Key)
+		log.SugarLogger.Errorln(errorMessage)
+		return nil, fmt.Errorf(errorMessage)
+	}
+
 	if err != nil {
 		log.SugarLogger.Errorln(fmt.Sprintf("Failed to create schema registry client: %s\n", err))
 		return nil, err


### PR DESCRIPTION
Se suma esta validación porque si por alguna razón el evento es nil se genera un panic y corta la ejecución.