### PR TITLE
fix-connect-mongo

### DIFF
--- a/dataBase/mongo.go
+++ b/dataBase/mongo.go
@@ -35,14 +35,22 @@ func NewMongoRepository(mongoURL, mongoDB, mongoMechanism, mongoUser, mongoPass 
 }
 
 func createConnectionMongo(mongoURL, mongoDB, mongoMechanism, mongoUser, mongoPass string) *mongo.Database {
+
+	var clientOptionsAuth *options.ClientOptions
+
 	clientOptions := options.Client().ApplyURI(mongoURL).
-		SetMonitor(apmmongo.CommandMonitor()).SetAuth(options.Credential{
-		AuthMechanism: mongoMechanism,
-		AuthSource:    mongoDB,
-		Username:      mongoUser,
-		Password:      mongoPass,
-	})
-	mongoClient, err := mongo.Connect(context.TODO(), clientOptions)
+		SetMonitor(apmmongo.CommandMonitor())
+
+	if mongoMechanism != "" && mongoUser != "" && mongoPass != "" {
+		clientOptionsAuth = options.Client().SetAuth(options.Credential{
+			AuthMechanism: mongoMechanism,
+			AuthSource:    mongoDB,
+			Username:      mongoUser,
+			Password:      mongoPass,
+		})
+	}
+
+	mongoClient, err := mongo.Connect(context.TODO(), clientOptions, clientOptionsAuth)
 	if err != nil || mongoDB == "" {
 		log.Logger.Error("Error Fatal NO se conectó a MongoDB, la url es: " + mongoURL +
 			" , la BBDD es: " + mongoDB + " . Verifique que sean correctos")


### PR DESCRIPTION
Se requiere implementar variables de conexión debido a un cambio de seguridad que se agrego por para de DBA a las bases de datos Mongo, las misma refieren con credenciales y mecanismo de autorización que se van a utilizar de ahora en adelante. 

1. Para la incorporación de estas nuevas variables en el código de nuestras apps de GO, debemos setearlas en donde se establezca como directorio para luego obtenerlas desde la función que establece la conexión, este es un caso de uso del repo local, lo mismo debería replicarse en los manifiestos de cada API para el correcto despliegue por CICD hacia OCP:
![image](https://github.com/architecture-it/go-platform/assets/79702447/0169b86b-338c-497d-8189-9836d4f69400)

2. Por ultimo, desde la función ya establecida en la ultima versión de platform para establecer la conexión simplemente obtenemos nuestras variables de Mongo y se la pasamos a la función NewMongoRepository del modulo Database

![image](https://github.com/architecture-it/go-platform/assets/79702447/12e2949a-7852-4e38-855a-203c61e0c725)


* En caso de que se pase mal escrita o el dato de alguna de las nuevas variables para la autorización de acceso a las db se generará un error con un mensaje aclaratorio al respecto, de este estilo(se dejan las variables como opcionales en caso de que no se requiera login en alguna base):
 
![image](https://github.com/architecture-it/go-platform/assets/79702447/53be8fbd-feba-47b5-b2a4-c840d4fe7297)