### PR TITLE
Correccion de reintentos de conexion Mongo

### DIFF
--- a/dataBase/mongo.go
+++ b/dataBase/mongo.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/architecture-it/go-platform/log"
 	"go.elastic.co/apm/module/apmmongo"
@@ -68,15 +69,49 @@ func createConnectionMongo(mongoURL, mongoDB, mongoMechanism, mongoUser, mongoPa
 	return db
 }
 
-// GetDB return the database connection
+// // GetDB return the database connection
+// func (repo *mongoRepository) GetDB(ctx context.Context) *mongo.Database {
+// 	// reintento de conexion si algo fallo
+// 	if repo.db == nil {
+// 		log.Logger.Info("Se intenta reconectar a mongo.")
+// 		repo.db = createConnectionMongo(repo.mongoURL, repo.mongoDB, repo.mongoMechanism, repo.mongoUser, repo.mongoPass)
+// 	}
+// 	if repo.db == nil {
+// 		return nil
+// 	}
+// 	return repo.db
+// }
+
+const (
+	maxRetries = 3
+)
+
 func (repo *mongoRepository) GetDB(ctx context.Context) *mongo.Database {
-	// reintento de conexion si algo fallo
-	if repo.db == nil {
-		log.Logger.Info("Se intenta reconectar a mongo.")
-		repo.db = createConnectionMongo(repo.mongoURL, repo.mongoDB, repo.mongoMechanism, repo.mongoUser, repo.mongoPass)
+	for i := 0; i < maxRetries; i++ {
+		if repo.db == nil {
+			log.Logger.Info("Intentando reconectar a MongoDB...")
+			repo.db = createConnectionMongo(repo.mongoURL, repo.mongoDB, repo.mongoMechanism, repo.mongoUser, repo.mongoPass)
+		}
+
+		if repo.db != nil {
+			err := repo.db.Client().Ping(ctx, nil)
+			if err == nil {
+				return repo.db
+			}
+
+			log.Logger.Error(fmt.Sprintf("Error de conexión a MongoDB: %s", err))
+
+			// Si hay un error de conexión, desconecta para forzar una reconexión en el próximo intento
+			if err := repo.db.Client().Disconnect(ctx); err != nil {
+				log.Logger.Info(fmt.Sprintf("Error de conexión a MongoDB: %s", err.Error()))
+			}
+			repo.db = nil
+		}
+
+		log.Logger.Info("Intentando nuevamente la conexión a MongoDB")
+
 	}
-	if repo.db == nil {
-		return nil
-	}
-	return repo.db
+
+	log.Logger.Error("No se pudo establecer la conexión después de varios intentos.")
+	return nil
 }

--- a/dataBase/mongo.go
+++ b/dataBase/mongo.go
@@ -69,19 +69,6 @@ func createConnectionMongo(mongoURL, mongoDB, mongoMechanism, mongoUser, mongoPa
 	return db
 }
 
-// // GetDB return the database connection
-// func (repo *mongoRepository) GetDB(ctx context.Context) *mongo.Database {
-// 	// reintento de conexion si algo fallo
-// 	if repo.db == nil {
-// 		log.Logger.Info("Se intenta reconectar a mongo.")
-// 		repo.db = createConnectionMongo(repo.mongoURL, repo.mongoDB, repo.mongoMechanism, repo.mongoUser, repo.mongoPass)
-// 	}
-// 	if repo.db == nil {
-// 		return nil
-// 	}
-// 	return repo.db
-// }
-
 const (
 	maxRetries = 3
 )


### PR DESCRIPTION
Debido a una caída de Mongo en QA, notamos que no se realizaba correctamente la reconexión a la bd y se debieron reiniciar los pods manualmente, en base a eso se hicieron pruebas localmente para configurar la reconexión correctamente simulando la caida de mongo. Las mismas respondieron como se esperaba.